### PR TITLE
Use hub-web signer helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,8 +8,8 @@
       "name": "permissionless-signups-demo",
       "version": "0.1.0",
       "dependencies": {
-        "@farcaster/hub-nodejs": "^0.10.11",
-        "@farcaster/hub-web": "^0.6.6",
+        "@farcaster/hub-nodejs": "^0.10.19",
+        "@farcaster/hub-web": "^0.7.1",
         "@heroicons/react": "^2.0.18",
         "@noble/ed25519": "^2.0.0",
         "@tailwindcss/forms": "^0.5.6",
@@ -433,9 +433,9 @@
       "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
     },
     "node_modules/@farcaster/core": {
-      "version": "0.12.11",
-      "resolved": "https://registry.npmjs.org/@farcaster/core/-/core-0.12.11.tgz",
-      "integrity": "sha512-u61lqKbqIk/pplcFL/lf8QjL7kWHYRITb9jPCqPHV7P6ZVIh/UR0PAkKRlM4BPfk2GgDY/lIFP2PyaOcrp89/Q==",
+      "version": "0.13.3",
+      "resolved": "https://registry.npmjs.org/@farcaster/core/-/core-0.13.3.tgz",
+      "integrity": "sha512-OI2ml+QKst9fwvpqJsmSqgK3goPsXkFU6AGmeuFuNAyGPQaRRB4MBS2YHQLkFpSZZ5bS82ENcx2CKAwTfh5Rwg==",
       "dependencies": {
         "@noble/curves": "^1.0.0",
         "@noble/hashes": "^1.3.0",
@@ -446,22 +446,22 @@
       }
     },
     "node_modules/@farcaster/hub-nodejs": {
-      "version": "0.10.11",
-      "resolved": "https://registry.npmjs.org/@farcaster/hub-nodejs/-/hub-nodejs-0.10.11.tgz",
-      "integrity": "sha512-HWRQeanQ3eEQ7yNWPosauh80nYLU3hsXYBC8nYz5uloE+IyAKJkZGHokVdPqX46Vwc2oo8nyIHRYqgwIgQm7eg==",
+      "version": "0.10.19",
+      "resolved": "https://registry.npmjs.org/@farcaster/hub-nodejs/-/hub-nodejs-0.10.19.tgz",
+      "integrity": "sha512-Hut5/xv30loCE2E05WaXxHjJsYoYp/wY+DnXq/7BaaCYhfbCO1x9O8GAOPrN0st8+SnGEh4WVeLZaG3D3+BSCw==",
       "dependencies": {
-        "@farcaster/core": "0.12.11",
+        "@farcaster/core": "0.13.3",
         "@grpc/grpc-js": "~1.8.21",
         "@noble/hashes": "^1.3.0",
         "neverthrow": "^6.0.0"
       }
     },
     "node_modules/@farcaster/hub-web": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@farcaster/hub-web/-/hub-web-0.6.6.tgz",
-      "integrity": "sha512-kqhBtZkK033Tt4IVffgiUrK6p+ePLq4UWPqBiKLZasMYgqWW5Eowq421xr58KPK2uYKMqd00tMfLKO914uv8Qg==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@farcaster/hub-web/-/hub-web-0.7.1.tgz",
+      "integrity": "sha512-cBcbfdWlM00tXxcKnoSVGiqvjqt/AEC9yQYDmbZnE6PoP1TzdA2ez/rrRuKswC90KB5JQVJLbPt+lb+azGmFyw==",
       "dependencies": {
-        "@farcaster/core": "^0.12.11",
+        "@farcaster/core": "^0.13.2",
         "@improbable-eng/grpc-web": "^0.15.0",
         "rxjs": "^7.8.0"
       }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@farcaster/hub-nodejs": "^0.10.11",
-    "@farcaster/hub-web": "^0.6.6",
+    "@farcaster/hub-nodejs": "^0.10.19",
+    "@farcaster/hub-web": "^0.7.1",
     "@heroicons/react": "^2.0.18",
     "@noble/ed25519": "^2.0.0",
     "@tailwindcss/forms": "^0.5.6",


### PR DESCRIPTION
We just added a helper to `@farcaster/core` that hides the gory details of signing and encoding key request metadata. Here's an example of how to use it.

Alternatively, if you want to keep using the wagmi `useSignTypedData` hook, you can import and use `SIGNED_KEY_REQUEST_VALIDATOR_EIP_712_TYPES`, which provides the domain and types for the `SignedKeyRequest` contract:

```typescript
import {
  NobleEd25519Signer,
  SIGNED_KEY_REQUEST_VALIDATOR_EIP_712_TYPES,
} from "@farcaster/hub-web";

const {
  data,
  isLoading: isLoadingSign,
  isSuccess: isSuccessSign,
  signTypedData,
} = useSignTypedData({
  ...SIGNED_KEY_REQUEST_VALIDATOR_EIP_712_TYPES,
  primaryType: "SignedKeyRequest",
  message: {
    requestFid: BigInt(fid),
    key: publicKey as `0x${string}`,
    deadline: BigInt(deadline),
  },
});
  ```