### PR TITLE
Lock connectkit to avoid issues with wagmi

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 /node_modules
 /.pnp
 .pnp.js
+pnpm-lock.yaml
 
 # testing
 /coverage

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@noble/ed25519": "^2.0.0",
     "@tailwindcss/forms": "^0.5.6",
     "axios": "^1.5.1",
-    "connectkit": "^1.5.3",
+    "connectkit": "1.6.0",
     "next": "13.5.4",
     "react": "^18",
     "react-dom": "^18",


### PR DESCRIPTION
Connectkit 1.7.0 upgrades wagmi / viem which causes errors for this repo. This locks the version and fixes the errors until repo can be upgraded to wagmi / viem 2.